### PR TITLE
Overall cleanup

### DIFF
--- a/superweb/db.py
+++ b/superweb/db.py
@@ -6,7 +6,7 @@ from peewee import *
 
 # Tworzymy obiekt bazy danych
 DB_PATH = str(pathlib.Path(__file__).with_name('todo.db'))
-db = SqliteDatabase(DB_PATH)
+backend = SqliteDatabase(DB_PATH)
 
 
 class Task(Model):
@@ -17,8 +17,6 @@ class Task(Model):
     completed_at = DateTimeField(null=True)
     deadline_at = DateTimeField(null=True)
 
-
-
     # Tutaj łączymy nasz model z bazą danych "db" zdefiniowaną wyżej.
     class Meta:
-        database = db
+        database = backend

--- a/superweb/rest.py
+++ b/superweb/rest.py
@@ -1,0 +1,13 @@
+import json
+import datetime
+
+
+def json_serializer_handler(obj):
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat()
+    else:
+        return None
+
+
+def json_dumps(obj):
+    return json.dumps(obj, default=json_serializer_handler)

--- a/superweb/tpl.py
+++ b/superweb/tpl.py
@@ -1,4 +1,3 @@
-import datetime
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -19,11 +18,3 @@ def render_template(name, context=None):
     rendered_template = template.render(context)
 
     return rendered_template
-
-
-def json_serializer_handler(obj):
-    """Funkcja pozwalająca serializować do jsona obiekt datetime"""
-    if isinstance(obj, (datetime.datetime, datetime.date)):
-        return obj.isoformat()
-    else:
-        return None

--- a/utils/db_create.py
+++ b/utils/db_create.py
@@ -1,7 +1,7 @@
 from superweb import database
 
-database.db.connect()
+database.backend.connect()
 
 tables = [database.Task]
-database.db.drop_tables(tables)
-database.db.create_tables(tables)
+database.backend.drop_tables(tables)
+database.backend.create_tables(tables)


### PR DESCRIPTION
- split superweb.base to superweb.tpl and superweb.rest
- concise naming for top-level packages (database -> db) and some objects (e.g. db backend)
- remove redundant (obvious) comments

I'm not sure if really needed.